### PR TITLE
solve the undefined nn error

### DIFF
--- a/inference_images.py
+++ b/inference_images.py
@@ -23,6 +23,7 @@ import os
 import shutil
 
 from torch.nn import functional as F
+import torch.nn as nn
 from torch.utils.data import DataLoader
 from torchvision import transforms as T
 from torchvision.transforms.functional import to_pil_image


### PR DESCRIPTION
it solves the problem reported in https://github.com/jinzishuai/BackgroundMattingV2/issues/3#issuecomment-752304242

```
(bgm2) C:\ZeroBox\src\BackgroundMattingV2> python inference_images.py --model-type mattingrefine --model-backbone resnet101 --model-checkpoint PyTorch\pytorch_resnet101.pth --images-src Group15BOriginals --images-bgr Group15BBackground --output-dir output1 --output-type com fgr pha  --model-refine-mode full
Traceback (most recent call last):
  File "inference_images.py", line 97, in <module>
    HomographicAlignment() if args.preprocess_alignment else A.PairApply(nn.Identity()),
NameError: name 'nn' is not defined
```