### PR TITLE
Improving performance of video inference and increase GPU utilization

### DIFF
--- a/inference_video.py
+++ b/inference_video.py
@@ -103,13 +103,13 @@ class VideoWriter:
             read_buffer = output_p.recv()
             # gracefully exit with provided exit code if it is an integer
             if type(read_buffer) == type(int):
-                out.release()
-                exit(read_buffer)
+                break
             frames = read_buffer.numpy()
             for i in range(frames.shape[0]):
                 frame = frames[i]
                 frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
                 out.write(frame)
+        out.release()
             
 
 class ImageSequenceWriter:

--- a/inference_video.py
+++ b/inference_video.py
@@ -102,7 +102,7 @@ class VideoWriter:
         while True:
             read_buffer = output_p.recv()
             # gracefully exit with provided exit code if it is an integer
-            if type(read_buffer) == type(int):
+            if type(read_buffer) == int:
                 break
             frames = read_buffer.numpy()
             for i in range(frames.shape[0]):

--- a/inference_video.py
+++ b/inference_video.py
@@ -243,8 +243,6 @@ with torch.no_grad():
             ref_writer.add_batch(F.interpolate(ref, src.shape[2:], mode='nearest'))
     # terminate children processes
     if args.output_format == 'video':
-        h = args.video_resize[1] if args.video_resize is not None else vid.height
-        w = args.video_resize[0] if args.video_resize is not None else vid.width
         if 'com' in args.output_types:
             com_writer.close()
         if 'pha' in args.output_types:

--- a/inference_video.py
+++ b/inference_video.py
@@ -35,7 +35,7 @@ from threading import Thread
 from tqdm import tqdm
 from PIL import Image
 
-from dataset import VideoDataset
+from dataset import VideoDataset, ZipDataset
 from dataset import augmentation as A
 from model import MattingBase, MattingRefine
 from inference_utils import HomographicAlignment


### PR DESCRIPTION
Two improvements are made in this contribution:

1. Removed repeated copying of background image to GPU memory, minimizing the effect of a memory bandwidth bottleneck
2. Increased GPU utilization by offloading the CPU video encoding to children threads as soon as it is copied to CPU memory, freeing up the parent process to begin processing the next frame
3. Further increased GPU utilization by offloading the CPU video decoding to another thread so that the main thread can focus on feeding the GPU

This modification allowed for about three times the performance on my system with R7 5800H and RTX3060 mobile. Using the same 4k video on both resnet50 and resnet101 models, the original version ran at 2.20it/s whereas this runs at an average of 7.5it/s.